### PR TITLE
Refactor success rate calculation into reusable helpers

### DIFF
--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -3,6 +3,7 @@ package output
 import (
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -68,8 +69,8 @@ func TestFormatJSON(t *testing.T) {
 	if !strings.Contains(output, `"https://example.com"`) {
 		t.Error("Expected endpoint in JSON output")
 	}
-	expected := fmt.Sprintf("\"success_rate\": %.0f", tester.OverallSuccessRate(results))
-	if strings.Count(output, expected) < 2 {
+	expected := strconv.FormatFloat(tester.OverallSuccessRate(results), 'f', -1, 64)
+	if strings.Count(output, fmt.Sprintf("\"success_rate\": %s", expected)) < 2 {
 		t.Errorf("Expected success rate %s to appear twice in JSON output", expected)
 	}
 }

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -1,6 +1,7 @@
 package output
 
 import (
+	"fmt"
 	"os"
 	"strings"
 	"testing"
@@ -38,6 +39,10 @@ func TestFormatMarkdown(t *testing.T) {
 	if !strings.Contains(output, "https://example.com") {
 		t.Error("Expected endpoint in output")
 	}
+	expected := fmt.Sprintf("%.2f%%", tester.OverallSuccessRate(results))
+	if strings.Count(output, expected) < 2 {
+		t.Errorf("Expected success rate %s to appear twice", expected)
+	}
 }
 
 func TestFormatJSON(t *testing.T) {
@@ -63,6 +68,10 @@ func TestFormatJSON(t *testing.T) {
 	if !strings.Contains(output, `"https://example.com"`) {
 		t.Error("Expected endpoint in JSON output")
 	}
+	expected := fmt.Sprintf("\"success_rate\": %.0f", tester.OverallSuccessRate(results))
+	if strings.Count(output, expected) < 2 {
+		t.Errorf("Expected success rate %s to appear twice in JSON output", expected)
+	}
 }
 
 func TestFormatCSV(t *testing.T) {
@@ -87,6 +96,10 @@ func TestFormatCSV(t *testing.T) {
 
 	if !strings.Contains(output, "https://example.com") {
 		t.Error("Expected endpoint in CSV output")
+	}
+	expected := fmt.Sprintf("%.2f%%", tester.OverallSuccessRate(results))
+	if strings.Count(output, expected) < 2 {
+		t.Errorf("Expected success rate %s to appear twice in CSV output", expected)
 	}
 }
 

--- a/internal/tester/metrics.go
+++ b/internal/tester/metrics.go
@@ -1,0 +1,17 @@
+package tester
+
+// OverallSuccessRate calculates the overall success rate as a percentage.
+func OverallSuccessRate(result *TestResult) float64 {
+	if result == nil || result.TotalRequests == 0 {
+		return 0
+	}
+	return float64(result.TotalRequests-result.TotalErrors) / float64(result.TotalRequests) * 100
+}
+
+// EndpointSuccessRate calculates the success rate for a single endpoint as a percentage.
+func EndpointSuccessRate(result *EndpointResult) float64 {
+	if result == nil || result.TotalRequests == 0 {
+		return 0
+	}
+	return float64(result.SuccessCount) / float64(result.TotalRequests) * 100
+}


### PR DESCRIPTION
## Summary
- add `OverallSuccessRate` and `EndpointSuccessRate` helpers to tester package
- delegate markdown, JSON, and CSV output success-rate calculations to helpers
- extend output formatting tests to assert success rates appear

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a4d477994083219a4ed30bf687d7cd