### PR TITLE
[codex] Bump Go to 1.26.2

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
-golang 1.25.4
+golang 1.26.2
 gosec 2.22.10
 golangci-lint 2.6.1
 staticcheck 0.6.0

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/benvon/http-request-reliability-tester
 
-go 1.25.4
+go 1.26.2

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -51,16 +51,16 @@ func formatMarkdown(results *tester.TestResult) (string, error) {
 
 	// Summary section
 	sb.WriteString("# HTTP Request Reliability Test Results\n\n")
-	sb.WriteString(fmt.Sprintf("**Test Duration:** %s\n", results.Duration))
-	sb.WriteString(fmt.Sprintf("**Start Time:** %s\n", results.StartTime.Format(time.RFC3339)))
-	sb.WriteString(fmt.Sprintf("**End Time:** %s\n", results.EndTime.Format(time.RFC3339)))
-	sb.WriteString(fmt.Sprintf("**Requests Per Minute:** %d\n\n", results.RequestsPerMinute))
+	fmt.Fprintf(&sb, "**Test Duration:** %s\n", results.Duration)
+	fmt.Fprintf(&sb, "**Start Time:** %s\n", results.StartTime.Format(time.RFC3339))
+	fmt.Fprintf(&sb, "**End Time:** %s\n", results.EndTime.Format(time.RFC3339))
+	fmt.Fprintf(&sb, "**Requests Per Minute:** %d\n\n", results.RequestsPerMinute)
 
 	// Overall statistics
 	sb.WriteString("## Overall Statistics\n\n")
-	sb.WriteString(fmt.Sprintf("- **Total Requests:** %d\n", results.TotalRequests))
-	sb.WriteString(fmt.Sprintf("- **Total Errors:** %d\n", results.TotalErrors))
-	sb.WriteString(fmt.Sprintf("- **Success Rate:** %.2f%%\n\n", tester.OverallSuccessRate(results)))
+	fmt.Fprintf(&sb, "- **Total Requests:** %d\n", results.TotalRequests)
+	fmt.Fprintf(&sb, "- **Total Errors:** %d\n", results.TotalErrors)
+	fmt.Fprintf(&sb, "- **Success Rate:** %.2f%%\n\n", tester.OverallSuccessRate(results))
 
 	// Error breakdown
 	if results.TotalErrors > 0 {
@@ -70,7 +70,7 @@ func formatMarkdown(results *tester.TestResult) (string, error) {
 
 		for errorType, count := range results.ErrorBreakdown {
 			percentage := float64(count) / float64(results.TotalErrors) * 100
-			sb.WriteString(fmt.Sprintf("| %s | %d | %.2f%% |\n", errorType, count, percentage))
+			fmt.Fprintf(&sb, "| %s | %d | %.2f%% |\n", errorType, count, percentage)
 		}
 		sb.WriteString("\n")
 	}
@@ -88,13 +88,13 @@ func formatMarkdown(results *tester.TestResult) (string, error) {
 			status = "Removed"
 		}
 
-		sb.WriteString(fmt.Sprintf("| %s | %d | %d | %.2f%% | %s | %s |\n",
+		fmt.Fprintf(&sb, "| %s | %d | %d | %.2f%% | %s | %s |\n",
 			endpointResult.Endpoint,
 			endpointResult.TotalRequests,
 			endpointResult.TotalErrors,
 			successRate,
 			endpointResult.AverageDuration,
-			status))
+			status)
 	}
 
 	return sb.String(), nil


### PR DESCRIPTION
## What changed
- bumped the repo Go toolchain from `1.25.4` to `1.26.2` in `go.mod`
- bumped the local `mise` pin in `.tool-versions` to keep local and CI toolchains aligned

## Why
- the April 8, 2026 `CI` workflow failure was in `govulncheck`, which reported Go standard-library vulnerabilities in `go1.25.4`
- this repo has no external module requirements to upgrade, so `go get -u ./...` did not produce any dependency changes
- the related fleet workflow-health issues were stale against current GitHub workflow state and were closed separately

## Impact
- CI and release workflows that read `go.mod` will use Go `1.26.2`
- local development via `mise` will use the same version

## Root cause
- the repo was pinned to an older Go toolchain with known stdlib vulnerabilities flagged by `govulncheck`

## Validation
- reviewed the exact April 8 failing GitHub Actions log for the `govulncheck` failure
- confirmed `go get -u ./...` is effectively a no-op for this repo's module graph
- attempted `go test ./...` under `mise` Go `1.26.2`; sandbox-local `httptest` socket binding prevented full completion here
- `git diff --check` is clean