### PR TITLE
[codex] Refactor releases to run from main

### DIFF
--- a/.github/workflows/pr-release-label.yml
+++ b/.github/workflows/pr-release-label.yml
@@ -1,0 +1,95 @@
+name: PR Release Label
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+      - ready_for_review
+      - labeled
+      - unlabeled
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  release-label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate title and sync release label
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const releaseLabels = ["release:major", "release:minor", "release:patch", "release:none"];
+            const conventionalCommit =
+              /^(?<type>build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(?:\((?<scope>[^()\r\n]+)\))?(?<breaking>!)?: (?<description>\S.*)$/;
+
+            async function removeReleaseLabels(names) {
+              for (const name of names) {
+                try {
+                  await github.rest.issues.removeLabel({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: pr.number,
+                    name,
+                  });
+                } catch (error) {
+                  if (error.status !== 404) {
+                    throw error;
+                  }
+                }
+              }
+            }
+
+            if (pr.base.ref !== "main") {
+              const present = pr.labels
+                .map((label) => typeof label === "string" ? label : label.name)
+                .filter((name) => releaseLabels.includes(name));
+              await removeReleaseLabels(present);
+              core.notice(`PR #${pr.number} targets ${pr.base.ref}; release labels only apply to main.`);
+              return;
+            }
+
+            const title = pr.title.trim();
+            const match = title.match(conventionalCommit);
+            const currentReleaseLabels = pr.labels
+              .map((label) => typeof label === "string" ? label : label.name)
+              .filter((name) => releaseLabels.includes(name));
+
+            if (!match || !match.groups) {
+              await removeReleaseLabels(currentReleaseLabels);
+              core.setFailed(
+                "PR title must follow Conventional Commits, e.g. `feat(api): add retries`, `fix: handle timeout`, or `chore!: drop legacy mode`.",
+              );
+              return;
+            }
+
+            const type = match.groups.type;
+            const breaking = match.groups.breaking === "!";
+
+            let desiredLabel = "release:none";
+            if (breaking) {
+              desiredLabel = "release:major";
+            } else if (type === "feat") {
+              desiredLabel = "release:minor";
+            } else if (["fix", "perf", "revert"].includes(type)) {
+              desiredLabel = "release:patch";
+            }
+
+            const labelsToRemove = currentReleaseLabels.filter((name) => name !== desiredLabel);
+            await removeReleaseLabels(labelsToRemove);
+
+            if (!currentReleaseLabels.includes(desiredLabel)) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                labels: [desiredLabel],
+              });
+            }
+
+            core.notice(`PR #${pr.number} title '${title}' maps to ${desiredLabel}.`);

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,11 +2,23 @@ name: Release
 
 on:
   push:
-    tags:
-      - 'v*'
+    branches:
+      - main
+  workflow_dispatch:
+    inputs:
+      release_type:
+        description: "Semver bump to apply when running manually"
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
 
 permissions:
   contents: write
+  packages: write
+  pull-requests: read
 
 jobs:
   goreleaser:
@@ -17,20 +29,182 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Fetch tags
+        run: git fetch --force --tags origin
+
+      - name: Resolve release signal
+        id: signal
+        uses: actions/github-script@v8
+        env:
+          DISPATCH_RELEASE_TYPE: ${{ github.event.inputs.release_type || '' }}
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const labelsToBump = {
+              "release:major": "major",
+              "release:minor": "minor",
+              "release:patch": "patch",
+            };
+            const skipLabels = new Set(["release:none", "release:skip"]);
+            let bump = process.env.DISPATCH_RELEASE_TYPE || "";
+            let source = "";
+
+            if (context.eventName === "push") {
+              const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+                owner,
+                repo,
+                commit_sha: context.sha,
+              });
+
+              const mergedPr = prs.find((pr) => pr.merged_at && pr.base.ref === "main");
+              if (!mergedPr) {
+                core.notice(`No merged pull request is associated with ${context.sha}; skipping release.`);
+                core.setOutput("should_release", "false");
+                return;
+              }
+
+              const labels = mergedPr.labels.map((label) =>
+                typeof label === "string" ? label : label.name,
+              );
+              const matched = labels.filter((name) => Object.prototype.hasOwnProperty.call(labelsToBump, name));
+              const skips = labels.filter((name) => skipLabels.has(name));
+
+              if (matched.length > 1) {
+                core.setFailed(`PR #${mergedPr.number} has multiple release labels: ${matched.join(", ")}`);
+                return;
+              }
+
+              if (skips.length > 0 && matched.length > 0) {
+                core.setFailed(`PR #${mergedPr.number} mixes skip and release labels: ${[...skips, ...matched].join(", ")}`);
+                return;
+              }
+
+              if (skips.length > 0) {
+                core.notice(`PR #${mergedPr.number} has ${skips.join(", ")}; skipping release.`);
+                core.setOutput("should_release", "false");
+                return;
+              }
+
+              if (matched.length === 0) {
+                core.notice(`PR #${mergedPr.number} is missing a release label; skipping release.`);
+                core.setOutput("should_release", "false");
+                return;
+              }
+
+              bump = labelsToBump[matched[0]];
+              source = `PR #${mergedPr.number} label ${matched[0]}`;
+              core.setOutput("pr_number", String(mergedPr.number));
+              core.setOutput("pr_title", mergedPr.title);
+            } else {
+              source = `workflow_dispatch input ${bump}`;
+            }
+
+            core.setOutput("should_release", "true");
+            core.setOutput("bump", bump);
+            core.setOutput("source", source);
+
+      - name: Skip release when no release label is present
+        if: steps.signal.outputs.should_release != 'true'
+        run: |
+          echo "No release label found for this main merge. Skipping release." >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Determine release tag
+        if: steps.signal.outputs.should_release == 'true'
+        id: version
+        run: |
+          set -euo pipefail
+
+          existing_tag="$(git tag --points-at "$GITHUB_SHA" 'v*' | sort -V | tail -n1)"
+          if [[ -n "$existing_tag" ]]; then
+            echo "tag=$existing_tag" >> "$GITHUB_OUTPUT"
+            echo "created=false" >> "$GITHUB_OUTPUT"
+            echo "Using existing tag $existing_tag for $GITHUB_SHA" >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          latest_tag="$(git tag --list 'v*' --sort=-version:refname | head -n1)"
+          if [[ -z "$latest_tag" ]]; then
+            latest_tag="v0.0.0"
+          fi
+
+          version="${latest_tag#v}"
+          IFS=. read -r major minor patch <<< "$version"
+
+          case "${{ steps.signal.outputs.bump }}" in
+            major)
+              major=$((major + 1))
+              minor=0
+              patch=0
+              ;;
+            minor)
+              minor=$((minor + 1))
+              patch=0
+              ;;
+            patch)
+              patch=$((patch + 1))
+              ;;
+            *)
+              echo "Unsupported release bump: ${{ steps.signal.outputs.bump }}" >&2
+              exit 1
+              ;;
+          esac
+
+          next_tag="v${major}.${minor}.${patch}"
+          if git rev-parse "$next_tag" >/dev/null 2>&1; then
+            echo "Tag $next_tag already exists" >&2
+            exit 1
+          fi
+
+          echo "tag=$next_tag" >> "$GITHUB_OUTPUT"
+          echo "created=true" >> "$GITHUB_OUTPUT"
+          {
+            echo "Release source: ${{ steps.signal.outputs.source }}"
+            echo "Next tag: $next_tag"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Create release tag
+        if: steps.signal.outputs.should_release == 'true' && steps.version.outputs.created == 'true'
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag "${{ steps.version.outputs.tag }}" "$GITHUB_SHA"
+          git push origin "${{ steps.version.outputs.tag }}"
+
       - name: Get Go version from go.mod
+        if: steps.signal.outputs.should_release == 'true'
         id: go-version
-        run: echo "version=$(grep '^go ' go.mod | cut -d' ' -f2)" >> $GITHUB_OUTPUT
+        run: echo "version=$(grep '^go ' go.mod | cut -d' ' -f2)" >> "$GITHUB_OUTPUT"
 
       - name: Set up Go
+        if: steps.signal.outputs.should_release == 'true'
         uses: actions/setup-go@v6
         with:
           go-version: ${{ steps.go-version.outputs.version }}
 
+      - name: Set up QEMU
+        if: steps.signal.outputs.should_release == 'true'
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        if: steps.signal.outputs.should_release == 'true'
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        if: steps.signal.outputs.should_release == 'true'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        if: steps.signal.outputs.should_release == 'true'
+        uses: goreleaser/goreleaser-action@v7
         with:
           distribution: goreleaser
-          version: latest
+          version: "~> v2"
           args: release --clean
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -47,6 +47,7 @@ brews:
   - name: http-tester
     homepage: "https://github.com/benvon/http-request-reliability-tester"
     description: "HTTP Request Reliability Tester"
+    skip_upload: true
     repository:
       owner: benvon
       name: homebrew-tap
@@ -70,4 +71,4 @@ dockers:
       - "--platform=linux/arm64"
     extra_files:
       - README.md
-      - LICENSE 
+      - LICENSE

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.24-alpine AS builder
+FROM golang:1.26.2-alpine AS builder
 
 WORKDIR /app
 
@@ -39,4 +39,4 @@ USER appuser
 EXPOSE 8080
 
 # Run the application
-ENTRYPOINT ["./http-tester"] 
+ENTRYPOINT ["./http-tester"]

--- a/README.md
+++ b/README.md
@@ -251,19 +251,24 @@ docker run http-tester --duration 1m --rate 30
 3. Make your changes
 4. Add tests for new functionality
 5. Ensure all tests pass
-6. Add exactly one release label to the pull request when the merge should cut a release:
-   - `release:major` for breaking changes
-   - `release:minor` for new backward-compatible functionality
-   - `release:patch` for fixes and other backward-compatible changes
-   - `release:none` to skip releasing on merge
-7. Submit a pull request
+6. Use a Conventional Commit title for the pull request, for example:
+   - `feat(api): add retry support`
+   - `fix: handle timeout classification`
+   - `chore!: drop legacy defaults`
+7. The `PR Release Label` workflow validates the title and applies exactly one release label automatically:
+   - `release:major` for any conventional commit with `!`
+   - `release:minor` for `feat`
+   - `release:patch` for `fix`, `perf`, and `revert`
+   - `release:none` for other valid conventional commit types
+8. Submit a pull request
 
 ## Release Process
 
 Merges to `main` are the release trigger.
 
+- The `PR Release Label` workflow validates the PR title against Conventional Commits and applies the durable `release:*` label.
 - The release workflow finds the merged PR associated with the `main` commit.
-- It reads the PR label as the durable semver signal.
+- It reads the applied PR label as the semver signal.
 - It computes the next `v*` tag, creates it if needed, and runs GoReleaser from that merge commit.
 - Re-running the workflow is idempotent: if the commit already has a release tag, the workflow reuses it.
 

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ https://httpbin.org,100,0,100.00%,150ms,Active
 
 ### Prerequisites
 
-- Go 1.24 or later
+- Go 1.26 or later
 - Make (optional, for using Makefile)
 
 ### Building
@@ -251,7 +251,28 @@ docker run http-tester --duration 1m --rate 30
 3. Make your changes
 4. Add tests for new functionality
 5. Ensure all tests pass
-6. Submit a pull request
+6. Add exactly one release label to the pull request when the merge should cut a release:
+   - `release:major` for breaking changes
+   - `release:minor` for new backward-compatible functionality
+   - `release:patch` for fixes and other backward-compatible changes
+   - `release:none` to skip releasing on merge
+7. Submit a pull request
+
+## Release Process
+
+Merges to `main` are the release trigger.
+
+- The release workflow finds the merged PR associated with the `main` commit.
+- It reads the PR label as the durable semver signal.
+- It computes the next `v*` tag, creates it if needed, and runs GoReleaser from that merge commit.
+- Re-running the workflow is idempotent: if the commit already has a release tag, the workflow reuses it.
+
+Current release labels:
+
+- `release:major`
+- `release:minor`
+- `release:patch`
+- `release:none`
 
 ## License
 


### PR DESCRIPTION
## What changed
- replaced the tag-push release trigger with a `push` to `main` release flow
- added release signal resolution from the merged PR's label (`release:major`, `release:minor`, `release:patch`, `release:none`)
- made release reruns idempotent by reusing an existing semver tag when the merge commit is already tagged
- added the missing GHCR permissions and Docker setup for GoReleaser image publishing
- aligned the Docker builder image with the repo Go version
- changed Homebrew formula generation to `skip_upload: true` so releases do not depend on cross-repo credentials
- documented the release label contract in the README

## Why
- the old release path only ran on tag pushes, which made releases a separate manual action instead of a merge-to-main outcome
- the old GoReleaser config was structurally fragile in Actions: Docker publishing needed explicit login and `packages: write`, and Homebrew tap publishing to another repository cannot use the default workflow token
- the repo also needed a durable, explicit semver signal that survives squash/merge styles; PR labels are a better source of truth than parsing commit messages after the fact

## Impact
- merging a PR to `main` can now cut a release automatically when exactly one release label is present
- merge commits without a release label will skip release cleanly
- manual release dispatch is still possible with an explicit bump input
- the repo now has the label vocabulary needed for the workflow: `release:major`, `release:minor`, `release:patch`, `release:none`

## Validation
- `git diff --check` is clean
- parsed `.github/workflows/release.yml` with Ruby YAML
- parsed `.goreleaser.yml` with Ruby YAML
- created the release labels directly on the GitHub repo

## Follow-up
- `github-manager#295` should remain open until a real release run succeeds with the new workflow