### PR TITLE
fix(ci): update reusable workflow refs

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   quality:
-    uses: benvon/reusable-workflows/.github/workflows/go-quality.yml@0a878c63c5a17372ecd27a1fd1fffd7c1b88e5d3
+    uses: benvon/reusable-workflows/.github/workflows/go-quality.yml@f70796de0a6527dbed267a64835c3cc81b8144e0
     with:
       quality_command: make ci-local
       coverage_file: coverage.out

--- a/.github/workflows/release-policy.yml
+++ b/.github/workflows/release-policy.yml
@@ -11,6 +11,6 @@ permissions:
 
 jobs:
   release-policy:
-    uses: benvon/reusable-workflows/.github/workflows/release-policy.yml@0a878c63c5a17372ecd27a1fd1fffd7c1b88e5d3
+    uses: benvon/reusable-workflows/.github/workflows/release-policy.yml@f70796de0a6527dbed267a64835c3cc81b8144e0
     with:
       pull_request_number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/release-policy.yml
+++ b/.github/workflows/release-policy.yml
@@ -7,7 +7,7 @@ on:
 permissions:
   contents: read
   issues: write
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   release-policy:

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -20,7 +20,7 @@ permissions:
 
 jobs:
   release-tag:
-    uses: benvon/reusable-workflows/.github/workflows/release-tag.yml@0a878c63c5a17372ecd27a1fd1fffd7c1b88e5d3
+    uses: benvon/reusable-workflows/.github/workflows/release-tag.yml@f70796de0a6527dbed267a64835c3cc81b8144e0
     with:
       caller_event_name: ${{ github.event_name }}
       caller_sha: ${{ github.sha }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,4 +11,4 @@ permissions:
 
 jobs:
   release:
-    uses: benvon/reusable-workflows/.github/workflows/go-goreleaser-release.yml@0a878c63c5a17372ecd27a1fd1fffd7c1b88e5d3
+    uses: benvon/reusable-workflows/.github/workflows/go-goreleaser-release.yml@f70796de0a6527dbed267a64835c3cc81b8144e0


### PR DESCRIPTION
## Summary
Bump this repo's reusable workflow references to benvon/reusable-workflows commit f70796de0a6527dbed267a64835c3cc81b8144e0.

## Why
This shared workflow revision includes the workflow permissions fix in release-policy and keeps the repo aligned on one reusable workflow commit.

## Validation
- Verified the updated workflow refs in the repo.
- Verified the git commit is signed.
- Updated the PR body after converting from draft to trigger the required release-policy check.